### PR TITLE
Bump dom-storage

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,8 @@
+{
+    "esnext": true,
+    "preset": "airbnb",
+    "validateIndentation": 4,
+    "safeContextKeyword": ["self"],
+    "disallowMultipleVarDecl": "exceptUndefined",
+    "requireTrailingComma": null
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,10 @@
+{
+  "node": true,
+
+  "curly": true,
+  "latedef": true,
+  "quotmark": true,
+  "undef": true,
+  "unused": true,
+  "trailing": true
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "btoa": "^1.1.2",
-    "dom-storage": "^2.0.1",
+    "dom-storage": "^2.0.2",
     "es6-object-assign": "^1.0.1",
     "hawk": "^4.0.0",
     "rename-keys": "^1.1.2"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* global Promise */
 /**
  * @module halfpenny
  */

--- a/src/utils/get-storage-engine.js
+++ b/src/utils/get-storage-engine.js
@@ -1,3 +1,5 @@
+/* global localStorage */
+
 var getDOMStorage = function() {
     var Storage = require('dom-storage');
     return new Storage(null, { strict: true });


### PR DESCRIPTION
Asana task: https://app.asana.com/0/37131652076106/82725233565687

The dom-storage we’re depending on, 2.0.1, doesn’t come with a license. Via node-browser-compat/dom-storage#6 it now has one.

**We’ll need to publish as 0.0.3 for MRN-Code/nodeapi#57 to work.**
